### PR TITLE
Fix ImageMagick detection on Windows

### DIFF
--- a/lib/heatmap/map.rb
+++ b/lib/heatmap/map.rb
@@ -4,8 +4,8 @@ module Heatmap
     attr_accessor :area
 
     def initialize
-      l = `which convert` || `where convert`
-      raise(RuntimeError, "You need to have ImageMagick installed!") if l.nil? || l.strip.empty?
+      location = `which convert` || `where convert`
+      raise(RuntimeError, "You need to have ImageMagick installed!") if location.nil? || location.strip.empty?
       @area = []
     end
 

--- a/lib/heatmap/map.rb
+++ b/lib/heatmap/map.rb
@@ -4,7 +4,8 @@ module Heatmap
     attr_accessor :area
 
     def initialize
-      raise(RuntimeError, "You need to have ImageMagick installed!") if `which convert`.strip.empty?
+      l = `which convert` || `where convert`
+      raise(RuntimeError, "You need to have ImageMagick installed!") if l.nil? || l.strip.empty?
       @area = []
     end
 


### PR DESCRIPTION
Map was using `which` to check for the existence of ImageMagick which doesn't exist on Windows. I added a null coalescing check using `where` that should work correctly in Windows.
